### PR TITLE
Feat/#30 게시글 좋아요 api 구현

### DIFF
--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -3,7 +3,13 @@ import type { CommentFormData, UpdateCommentParams } from 'types';
 
 const createComment = async (formData: CommentFormData) => {
   try {
-    const { data, error } = await supabase.from('comment').insert(formData).select();
+    const user = await supabase.auth.getUser();
+    const userId = user.data.user?.id;
+
+    const { data, error } = await supabase
+      .from('comment')
+      .insert({ user_id: userId, ...formData })
+      .select();
 
     if (error) {
       throw error;

--- a/src/api/postLike.ts
+++ b/src/api/postLike.ts
@@ -1,0 +1,47 @@
+import { supabase } from 'lib/supabase';
+
+const addLike = async ({ postId }: { postId: string }) => {
+  try {
+    const user = await supabase.auth.getUser();
+    const userId = user.data.user?.id;
+
+    if (!userId) {
+      throw new Error('User not authenticated');
+    }
+
+    const { error } = await supabase
+      .from('post_likes')
+      .insert({ post_id: postId, user_id: userId });
+
+    if (error) throw error;
+    return { success: true };
+  } catch (error) {
+    console.error('Error adding like:', error);
+    throw error;
+  }
+};
+
+const removeLike = async ({ postId }: { postId: string }) => {
+  try {
+    const user = await supabase.auth.getUser();
+    const userId = user.data.user?.id;
+
+    if (!userId) {
+      throw new Error('User not authenticated');
+    }
+
+    const { error } = await supabase
+      .from('post_likes')
+      .delete()
+      .eq('post_id', postId)
+      .eq('user_id', userId);
+
+    if (error) throw error;
+    return { success: true };
+  } catch (error) {
+    console.error('Error removing like:', error);
+    throw error;
+  }
+};
+
+export { addLike, removeLike };

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -2,6 +2,6 @@ import type { Database } from './supabase';
 
 type CommentData = Database['public']['Tables']['comment']['Row'];
 
-export type CommentFormData = Pick<CommentData, 'post_id' | 'user_id' | 'content'>;
+export type CommentFormData = Pick<CommentData, 'post_id' | 'content'>;
 
 export type UpdateCommentParams = Pick<CommentData, 'comment_id' | 'content'>;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -2,7 +2,7 @@ import type { Database } from './supabase';
 
 type PostData = Database['public']['Tables']['posts']['Row'];
 
-export interface CreatePostFormData extends Pick<PostData, 'title' | 'content' | 'user_id'> {
+export interface CreatePostFormData extends Pick<PostData, 'title' | 'content'> {
   book_id?: string;
 }
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -87,32 +87,81 @@ export type Database = {
           },
         ]
       }
+      post_likes: {
+        Row: {
+          created_at: string
+          id: string
+          post_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          post_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          post_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "post_likes_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["post_id"]
+          },
+          {
+            foreignKeyName: "post_likes_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "userinfo"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       posts: {
         Row: {
+          book_id: string | null
           content: string
           created_at: string
+          likes_count: number
           post_id: string
           title: string
           updated_at: string
           user_id: string
         }
         Insert: {
+          book_id?: string | null
           content: string
           created_at?: string
+          likes_count?: number
           post_id?: string
           title: string
           updated_at?: string
           user_id: string
         }
         Update: {
+          book_id?: string | null
           content?: string
           created_at?: string
+          likes_count?: number
           post_id?: string
           title?: string
           updated_at?: string
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "posts_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "posts_user_id_fkey1"
             columns: ["user_id"]


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #30 

<br/>

## 💭 작업 내용

- 게시글 좋아요 api 구현
- post, comment 생성 시, userid를 parameter로 전달하는 것이 아닌 api에서 userInfo를 받아와서 전달하도록 수정
