### PR TITLE
Fix/#35 슬라이더 스크롤 이벤트 버그 수정

### DIFF
--- a/src/hooks/useSlider.ts
+++ b/src/hooks/useSlider.ts
@@ -40,7 +40,7 @@ export const useSlider = ({ data }: { data: BookData[] }) => {
     (event: WheelEvent) => {
       handleWheel(event.deltaY, images, sliderTl, tracker);
     },
-    [images, sliderTl, tracker],
+    [images],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- Closes #35

<br/>

## 💭 작업 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- 슬라이더 스크롤 이벤트 내 gsap.to 메소드의 tl 미반영 문제가 있어, 이를 수정했습니다.


<br/>

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![KR - Chrome 2024-11-01 16-12-54](https://github.com/user-attachments/assets/97460db5-3bde-4584-84bd-47cb90ad103d)
